### PR TITLE
Automatically set release version in archetype instances

### DIFF
--- a/compass-custom-archetype/pom.xml
+++ b/compass-custom-archetype/pom.xml
@@ -54,6 +54,13 @@
 			</resource>
 		</resources>
 
+		<testResources>
+			<testResource>
+				<directory>src/test/resources</directory>
+				<filtering>true</filtering>
+			</testResource>
+		</testResources>
+
 		<pluginManagement>
 			<plugins>
 				<plugin>

--- a/compass-custom-archetype/pom.xml
+++ b/compass-custom-archetype/pom.xml
@@ -14,7 +14,7 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 
-	<name>COMPASS - Custom Project Archetype</name>	
+	<name>COMPASS - Custom Project Archetype</name>
 	<artifactId>compass-custom-archetype</artifactId>
 	<packaging>maven-archetype</packaging>
 

--- a/compass-custom-archetype/pom.xml
+++ b/compass-custom-archetype/pom.xml
@@ -37,7 +37,7 @@
 
 		<resources>
 			<resource>
-				<!-- only filder metadata (to include version) -->
+				<!-- only filter metadata (to include version) -->
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
 				<includes>

--- a/compass-custom-archetype/pom.xml
+++ b/compass-custom-archetype/pom.xml
@@ -35,6 +35,25 @@
 			</extension>
 		</extensions>
 
+		<resources>
+			<resource>
+				<!-- only filder metadata (to include version) -->
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>META-INF/maven/archetype-metadata.xml</include>
+				</includes>
+			</resource>
+			<resource>
+				<!-- copy other non-metadata resources as-is -->
+				<directory>src/main/resources</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>META-INF/maven/archetype-metadata.xml</exclude>
+				</excludes>
+			</resource>
+		</resources>
+
 		<pluginManagement>
 			<plugins>
 				<plugin>

--- a/compass-custom-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/compass-custom-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -2,6 +2,11 @@
 <archetype-descriptor xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd" name="root"
 					  xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
 					  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<requiredProperties>
+		<requiredProperty key="compassVersion">
+			<defaultValue>${project.version}</defaultValue>
+		</requiredProperty>
+	</requiredProperties>
 	<modules>
 		<module id="model" dir="model" name="model">
 			<fileSets>

--- a/compass-custom-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/compass-custom-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archetype-descriptor xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd" name="root"
-    xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modules>
-    <module id="model" dir="model" name="model">
-      <fileSets>
-        <fileSet filtered="true" packaged="true" encoding="UTF-8">
-          <directory>src/main/java</directory>
-          <includes>
-            <include>**/*.java</include>
-          </includes>
-        </fileSet>
-      </fileSets>
-    </module>
-    <module id="persistence-unit" dir="persistence-unit" name="persistence-unit">
-      <fileSets>
-        <fileSet filtered="true" encoding="UTF-8">
-          <directory>src/main/resources</directory>
-          <includes>
-            <include>**/*.xml</include>
-          </includes>
-        </fileSet>
-      </fileSets>
-    </module>
-    <module id="webapp" dir="webapp" name="webapp">
-      <fileSets>
-        <fileSet filtered="true" encoding="UTF-8">
-          <directory>src/main/webapp</directory>
-          <includes>
-            <include>**/*.xhtml</include>
-          </includes>
-        </fileSet>
-      </fileSets>
-    </module>
-    <module id="deployment" dir="deployment" name="deployment" />
-    <module id="business-impl" dir="business-impl" name="business-impl">
-      <fileSets>
-        <fileSet filtered="true" packaged="true" encoding="UTF-8">
-          <directory>src/main/java</directory>
-          <includes>
-            <include>**/*.java</include>
-          </includes>
-        </fileSet>
-      </fileSets>
-    </module>
-  </modules>
+					  xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
+					  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modules>
+		<module id="model" dir="model" name="model">
+			<fileSets>
+				<fileSet filtered="true" packaged="true" encoding="UTF-8">
+					<directory>src/main/java</directory>
+					<includes>
+						<include>**/*.java</include>
+					</includes>
+				</fileSet>
+			</fileSets>
+		</module>
+		<module id="persistence-unit" dir="persistence-unit" name="persistence-unit">
+			<fileSets>
+				<fileSet filtered="true" encoding="UTF-8">
+					<directory>src/main/resources</directory>
+					<includes>
+						<include>**/*.xml</include>
+					</includes>
+				</fileSet>
+			</fileSets>
+		</module>
+		<module id="webapp" dir="webapp" name="webapp">
+			<fileSets>
+				<fileSet filtered="true" encoding="UTF-8">
+					<directory>src/main/webapp</directory>
+					<includes>
+						<include>**/*.xhtml</include>
+					</includes>
+				</fileSet>
+			</fileSets>
+		</module>
+		<module id="deployment" dir="deployment" name="deployment" />
+		<module id="business-impl" dir="business-impl" name="business-impl">
+			<fileSets>
+				<fileSet filtered="true" packaged="true" encoding="UTF-8">
+					<directory>src/main/java</directory>
+					<includes>
+						<include>**/*.java</include>
+					</includes>
+				</fileSet>
+			</fileSets>
+		</module>
+	</modules>
 </archetype-descriptor>

--- a/compass-custom-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/compass-custom-archetype/src/main/resources/archetype-resources/pom.xml
@@ -15,7 +15,7 @@
 		<failOnMissingWebXml>false</failOnMissingWebXml>
 		<skipITs>true</skipITs>
 		<ejb.ejbVersion>3.1</ejb.ejbVersion>
-		<compass.version>1.0-SNAPSHOT</compass.version>
+		<compass.version>${compassVersion}</compass.version>
 	</properties>
 
 	<build>

--- a/compass-custom-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/compass-custom-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ package=it.pkg
 version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=basic
-compassVersion=1.0-SNAPSHOT
+compassVersion=${project.version}

--- a/compass-custom-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/compass-custom-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,3 +3,4 @@ package=it.pkg
 version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=basic
+compassVersion=1.0-SNAPSHOT


### PR DESCRIPTION
When a project is created using archetype release X.Y the `compass.version` property in the newly created pom should say X.Y as well. This feature accomplishes that.
