### PR TITLE
Annotation cleanup and PMD rules

### DIFF
--- a/compass-maven-resources/src/main/resources/compass-java-ruleset.xml
+++ b/compass-maven-resources/src/main/resources/compass-java-ruleset.xml
@@ -156,6 +156,26 @@
 	<rule ref="rulesets/java/unnecessary.xml"/>
 	<rule ref="rulesets/java/unusedcode.xml"/>
 
+	<rule name="AnnotationValueOnly"
+	      message="Omit &quot;value =&quot; from annotation if value is the only argument"
+	      class="net.sourceforge.pmd.lang.rule.XPathRule"
+	      language="java">
+		<description>
+			Omit &quot;value =&quot; from annotation if value is the only argument
+		</description>
+		<properties>
+			<property name="xpath">
+				<value>
+					<![CDATA[
+					//NormalAnnotation/MemberValuePairs[
+						count(./MemberValuePair) = 1
+						and ./MemberValuePair[@Image = "value"]
+					]
+					]]>
+				</value>
+			</property>
+		</properties>
+	</rule>
 	<rule name="SwaggerReturnTypeRedundant"
 	      message="@ApiOperation(response = &lt;class&gt;) is redundant, function already returns &lt;class&gt;"
 	      class="net.sourceforge.pmd.lang.rule.XPathRule"

--- a/compass-maven-resources/src/main/resources/compass-java-ruleset.xml
+++ b/compass-maven-resources/src/main/resources/compass-java-ruleset.xml
@@ -155,4 +155,27 @@
 	<rule ref="rulesets/java/typeresolution.xml"/>
 	<rule ref="rulesets/java/unnecessary.xml"/>
 	<rule ref="rulesets/java/unusedcode.xml"/>
+
+	<rule name="SwaggerReturnTypeRedundant"
+	      message="@ApiOperation(response = &lt;class&gt;) is redundant, function already returns &lt;class&gt;"
+	      class="net.sourceforge.pmd.lang.rule.XPathRule"
+	      language="java">
+		<properties>
+			<property name="xpath">
+				<value>
+					<![CDATA[
+						//MethodDeclaration[
+							./ResultType/Type/
+								ReferenceType/ClassOrInterfaceType/@Image
+							=
+							../Annotation//Name[@Image="ApiOperation"]/
+								..//MemberValuePair[@Image="response"]//
+								ResultType/Type/
+								ReferenceType/ClassOrInterfaceType/@Image
+						]
+					]]>
+				</value>
+			</property>
+		</properties>
+	</rule>
 </ruleset>

--- a/compass-model/src/main/java/de/dfki/asr/compass/model/components/DirectionalLight.java
+++ b/compass-model/src/main/java/de/dfki/asr/compass/model/components/DirectionalLight.java
@@ -20,7 +20,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.NONE)
 @CompassComponent(ui = "/WEB-INF/components/directional-light.xhtml", icon = "status-weather-clear")
-@JsonSubTypes.Type(value = DirectionalLight.class)
+@JsonSubTypes.Type(DirectionalLight.class)
 public class DirectionalLight extends AbstractLight implements Serializable {
 	private static final long serialVersionUID = -8970757528356744465L;
 

--- a/compass-model/src/main/java/de/dfki/asr/compass/model/components/PreviewImage.java
+++ b/compass-model/src/main/java/de/dfki/asr/compass/model/components/PreviewImage.java
@@ -19,7 +19,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @CompassComponent(ui = "/WEB-INF/components/preview-image.xhtml", icon = "mimetypes-image-x-generic")
-@JsonSubTypes.Type(value = PreviewImage.class)
+@JsonSubTypes.Type(PreviewImage.class)
 @XmlRootElement
 public class PreviewImage extends SceneNodeComponent {
 

--- a/compass-model/src/main/java/de/dfki/asr/compass/model/components/RenderGeometry.java
+++ b/compass-model/src/main/java/de/dfki/asr/compass/model/components/RenderGeometry.java
@@ -16,7 +16,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
 @CompassComponent(ui = "/WEB-INF/components/rendergeometry.xhtml", icon = "")
-@JsonSubTypes.Type(value = RenderGeometry.class)
+@JsonSubTypes.Type(RenderGeometry.class)
 @XmlRootElement
 public class RenderGeometry extends SceneNodeComponent implements Serializable {
 

--- a/compass-rest/src/main/java/de/dfki/asr/compass/rest/ImageRESTService.java
+++ b/compass-rest/src/main/java/de/dfki/asr/compass/rest/ImageRESTService.java
@@ -41,9 +41,7 @@ public class ImageRESTService {
 	@GET
 	@Path("/{id}")
 	@Produces("image/*")
-	@ApiOperation(
-			value = "Get a image specified by its id."
-	)
+	@ApiOperation("Get a image specified by its id.")
 	@ApiResponses({
 		@ApiResponse(code = 400, message = "Bad Request"),
 		@ApiResponse(code = 404, message = "Entity not found.")

--- a/compass-rest/src/main/java/de/dfki/asr/compass/rest/PrefabSetRESTService.java
+++ b/compass-rest/src/main/java/de/dfki/asr/compass/rest/PrefabSetRESTService.java
@@ -72,9 +72,7 @@ public class PrefabSetRESTService extends AbstractRESTService {
 	@POST
 	@Path("/{id}/children")
 	@Consumes(MediaType.APPLICATION_JSON)
-	@ApiOperation(
-			value = "Append a prefabset to a specified parent."
-	)
+	@ApiOperation("Append a prefabset to a specified parent.")
 	@ApiResponses({
 		@ApiResponse(code = 400, message = "Bad Request"),
 		@ApiResponse(code = 404, message = "Entity not found"),
@@ -92,9 +90,7 @@ public class PrefabSetRESTService extends AbstractRESTService {
 
 	@POST
 	@Consumes(MediaType.APPLICATION_JSON)
-	@ApiOperation(
-			value = "Creates a prefab set."
-	)
+	@ApiOperation("Creates a prefab set.")
 	@ApiResponses({
 		@ApiResponse(code = 400, message = "Bad Request"),
 		@ApiResponse(code = 422, message = "Unprocessable Entity")
@@ -158,9 +154,7 @@ public class PrefabSetRESTService extends AbstractRESTService {
 	@PUT
 	@Path("/{id}")
 	@Consumes(MediaType.APPLICATION_JSON)
-	@ApiOperation(
-			value = "Update the current prefab"
-	)
+	@ApiOperation("Update the current prefab")
 	@ApiResponses({
 		@ApiResponse(code = 400, message = "Bad Request"),
 		@ApiResponse(code = 404, message = "Entity not found"),
@@ -178,9 +172,7 @@ public class PrefabSetRESTService extends AbstractRESTService {
 
 	@DELETE
 	@Path("/{id}")
-	@ApiOperation(
-			value = "Delete a prefab set."
-	)
+	@ApiOperation("Delete a prefab set.")
 	@ApiResponses({
 		@ApiResponse(code = 404, message = "Entity not found")
 	})

--- a/compass-rest/src/main/java/de/dfki/asr/compass/rest/PrefabSetRESTService.java
+++ b/compass-rest/src/main/java/de/dfki/asr/compass/rest/PrefabSetRESTService.java
@@ -59,10 +59,7 @@ public class PrefabSetRESTService extends AbstractRESTService {
 	@GET
 	@Path("/{id}")
 	@Produces(MediaType.APPLICATION_JSON)
-	@ApiOperation(
-			value = "Get a prefabset.",
-			response = PrefabSet.class
-	)
+	@ApiOperation("Get a prefabset.")
 	@ApiResponses({
 		@ApiResponse(code = 404, message = "Entity not found")
 	})

--- a/compass-rest/src/main/java/de/dfki/asr/compass/rest/ProjectRESTService.java
+++ b/compass-rest/src/main/java/de/dfki/asr/compass/rest/ProjectRESTService.java
@@ -155,9 +155,7 @@ public class ProjectRESTService extends AbstractRESTService {
 
 	@DELETE
 	@Path("/{id}")
-	@ApiOperation(
-			value = "Delete a project."
-	)
+	@ApiOperation("Delete a project.")
 	@ApiResponses({
 		@ApiResponse(code = 404, message = "Entity not found")
 	})

--- a/compass-rest/src/main/java/de/dfki/asr/compass/rest/ProjectRESTService.java
+++ b/compass-rest/src/main/java/de/dfki/asr/compass/rest/ProjectRESTService.java
@@ -59,8 +59,7 @@ public class ProjectRESTService extends AbstractRESTService {
 	@Produces(MediaType.APPLICATION_JSON)
 	@ApiOperation(
 			value = "Get a project",
-			notes = "Returns the requested project encoded as json.",
-			response = Project.class
+			notes = "Returns the requested project encoded as json."
 	)
 	@ApiResponses({
 		@ApiResponse(code = 404, message = "Entity not found")
@@ -76,13 +75,12 @@ public class ProjectRESTService extends AbstractRESTService {
 	@Produces(MediaType.APPLICATION_XML)
 	@ApiOperation(
 			value = "Get a project",
-			notes = "Returns the requested project encoded as XML",
-			response = Project.class
+			notes = "Returns the requested project encoded as XML"
 	)
 	@ApiResponses({
 		@ApiResponse(code = 404, message = "Entity not found")
 	})
-	public Object handleGetProjectByIdAsXML(
+	public Project handleGetProjectByIdAsXML(
 			@ApiParam(value = "id of the project", required = true)
 			@PathParam("id") final long entityId) throws EntityNotFoundException {
 		return projectManager.findById(entityId);

--- a/compass-rest/src/main/java/de/dfki/asr/compass/rest/ScenarioRESTService.java
+++ b/compass-rest/src/main/java/de/dfki/asr/compass/rest/ScenarioRESTService.java
@@ -82,9 +82,7 @@ public class ScenarioRESTService extends AbstractRESTService {
 
 	@Path("/{id}")
 	@DELETE
-	@ApiOperation(
-		value = "Delete a scenario."
-	)
+	@ApiOperation("Delete a scenario.")
 	@ApiResponses({
 		@ApiResponse(code = 404, message = "Entity not found")
 	})

--- a/compass-rest/src/main/java/de/dfki/asr/compass/rest/ScenarioRESTService.java
+++ b/compass-rest/src/main/java/de/dfki/asr/compass/rest/ScenarioRESTService.java
@@ -46,10 +46,7 @@ public class ScenarioRESTService extends AbstractRESTService {
 	@GET
 	@Path("/{id}")
 	@Produces(MediaType.APPLICATION_JSON)
-	@ApiOperation(
-			value = "Get a scenario.",
-			response = Scenario.class
-	)
+	@ApiOperation("Get a scenario.")
 	@ApiResponses({
 		@ApiResponse(code = 404, message = "Entity not found.")
 	})

--- a/compass-rest/src/main/java/de/dfki/asr/compass/rest/SceneNodeComponentRESTService.java
+++ b/compass-rest/src/main/java/de/dfki/asr/compass/rest/SceneNodeComponentRESTService.java
@@ -81,9 +81,7 @@ public class SceneNodeComponentRESTService extends AbstractRESTService {
 
 	@DELETE
 	@Path("/{id}")
-	@ApiOperation(
-			value = "Delete a scene node component"
-	)
+	@ApiOperation("Delete a scene node component")
 	@ApiResponses({
 		@ApiResponse(code = 404, message = "Entity not found.")
 	})

--- a/compass-rest/src/main/java/de/dfki/asr/compass/rest/SceneNodeComponentRESTService.java
+++ b/compass-rest/src/main/java/de/dfki/asr/compass/rest/SceneNodeComponentRESTService.java
@@ -45,10 +45,7 @@ public class SceneNodeComponentRESTService extends AbstractRESTService {
 	@GET
 	@Path("/{id}")
 	@Produces(MediaType.APPLICATION_JSON)
-	@ApiOperation(
-			value = "Get a scene node component",
-			response = SceneNodeComponent.class
-	)
+	@ApiOperation("Get a scene node component")
 	@ApiResponses({
 		@ApiResponse(code = 404, message = "Entity not found.")
 	})

--- a/compass-rest/src/main/java/de/dfki/asr/compass/rest/SceneNodeRESTService.java
+++ b/compass-rest/src/main/java/de/dfki/asr/compass/rest/SceneNodeRESTService.java
@@ -87,9 +87,7 @@ public class SceneNodeRESTService extends AbstractRESTService {
 
 	@POST
 	@Path("/{parentId}/children")
-	@ApiOperation(
-			value = "Create a scene node based on a prefab. Add it to the specified parent"
-	)
+	@ApiOperation("Create a scene node based on a prefab. Add it to the specified parent")
 	@ApiResponses({
 		@ApiResponse(code = 400, message = "Bad Request"),
 		@ApiResponse(code = 404, message = "Entity not found"),
@@ -153,9 +151,7 @@ public class SceneNodeRESTService extends AbstractRESTService {
 
 	@DELETE
 	@Path("/{id}")
-	@ApiOperation(
-		value = "Delete a scene node."
-	)
+	@ApiOperation("Delete a scene node.")
 	public Response handleDeleteEntity(
 			@ApiParam(value = "Scene node id", required = true)
 			@PathParam("id") final long entityId) throws EntityNotFoundException {

--- a/compass-rest/src/main/java/de/dfki/asr/compass/rest/SceneNodeRESTService.java
+++ b/compass-rest/src/main/java/de/dfki/asr/compass/rest/SceneNodeRESTService.java
@@ -52,10 +52,7 @@ public class SceneNodeRESTService extends AbstractRESTService {
 	@GET
 	@Path("/{id}")
 	@Produces(MediaType.APPLICATION_JSON)
-	@ApiOperation(
-			value = "Get a scene node.",
-			response = SceneNode.class
-	)
+	@ApiOperation("Get a scene node.")
 	@ApiResponses({
 		@ApiResponse(code = 404, message = "Entity not found.")
 	})


### PR DESCRIPTION
While working on REST stuff, I was really annoyed by annotations with unnecessary `value = "Foo"` attributes (where `"Foo"` would have sufficed), so I wrote a PMD rule against that. A few other occurences turned up, which were subsequently fixed.

While fixing the Swagger annotations (which were the most frequent offenders) I stumbled across redundant `response =` declarations. Removing these gave a few more minimal `"Foo"`-type annotations. And a PMD rule to not repeat that again.
