### PR TITLE
Extension points for JSF pages.

### DIFF
--- a/compass-webapp/src/main/java/de/dfki/asr/compass/web/components/PluginTagHandler.java
+++ b/compass-webapp/src/main/java/de/dfki/asr/compass/web/components/PluginTagHandler.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of COMPASS. It is subject to the license terms in
+ * the LICENSE file found in the top-level directory of this distribution.
+ * (Also avialable at http://www.apache.org/licenses/LICENSE-2.0.txt)
+ * You may not use this file except in compliance with the License.
+ */
+package de.dfki.asr.compass.web.components;
+
+import de.dfki.asr.compass.rest.util.CDIInjector;
+import de.dfki.asr.compass.web.plugins.PluginViewRegistry;
+import java.io.IOException;
+import java.util.List;
+import javax.faces.component.UIComponent;
+import javax.faces.component.UINamingContainer;
+import javax.faces.view.facelets.ComponentHandler;
+import javax.faces.view.facelets.FaceletContext;
+import javax.faces.view.facelets.Tag;
+import javax.faces.view.facelets.TagAttribute;
+import javax.faces.view.facelets.TagAttributeException;
+import javax.faces.view.facelets.TagConfig;
+import javax.faces.view.facelets.TagException;
+import javax.faces.view.facelets.TagHandler;
+import javax.inject.Inject;
+import org.jboss.logging.Logger;
+
+public class PluginTagHandler extends TagHandler {
+
+	private final TagAttribute slotAttribute;
+
+	@Inject
+	private PluginViewRegistry registry;
+
+	@Inject
+	private Logger log;
+
+	public PluginTagHandler(TagConfig config) {
+		super(config);
+		new CDIInjector<PluginTagHandler>().inject(this);
+		slotAttribute = getAttribute("slot");
+		if (slotAttribute == null) {
+			throw new TagException(tag, "Attribute 'slot' is required");
+		}
+	}
+
+	@Override
+	public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
+		String slot = slotAttribute.getValue(ctx);
+		if (slot == null || slot.length() == 0) {
+			return;
+		}
+		PluginTagProcessor p = new PluginTagProcessor(ctx, parent, tag, slotAttribute);
+		p.apply();
+		this.nextHandler.apply(ctx, p.getWrapper());
+	}
+
+	private class PluginTagProcessor {
+		private final FaceletContext context;
+		private final UIComponent parent;
+		private final TagAttribute slot;
+		private final Tag tag;
+
+		private boolean wrapperCreated = false;
+		private UINamingContainer wrapper;
+
+		public PluginTagProcessor(FaceletContext ctx, UIComponent parent, Tag tag, TagAttribute slot) {
+			this.context = ctx;
+			this.parent = parent;
+			this.slot = slot;
+			this.tag = tag;
+		}
+
+		public void apply() {
+			ensureWrappingContainer();
+			if (wrapperCreated) {
+				populateWrapper();
+				parent.getChildren().add(wrapper);
+			}
+		}
+
+		private void ensureWrappingContainer() {
+			if (ComponentHandler.isNew(parent)) {
+				wrapper = new UINamingContainer();
+				wrapper.setId(getWrapperId());
+				wrapperCreated = true;
+			} else {
+				UIComponent wrapperCandidate = parent.findComponent(getWrapperId());
+				if (wrapperCandidate instanceof UINamingContainer) {
+					wrapper = (UINamingContainer) wrapperCandidate;
+				} else {
+					wrapper = new UINamingContainer();
+					wrapper.setId(getWrapperId());
+					wrapperCreated = true;
+				}
+			}
+		}
+
+		private void populateWrapper() {
+			String actualSlot = slot.getValue(context);
+			List<String> viewsForSlot = registry.getViewIdsForSlot(actualSlot);
+			String lastTriedView = "";
+			try {
+				for (String viewId : viewsForSlot) {
+					lastTriedView = viewId;
+					context.includeFacelet(wrapper, viewId);
+				}
+			} catch (IOException e) {
+				throw new TagAttributeException(tag, slot, "Invalid path : " + lastTriedView);
+			}
+		}
+
+		private UIComponent getWrapper() {
+			return wrapper;
+		}
+
+		private String getWrapperId() {
+			return "compass_plugin_wrap_" + slot.getValue(context);
+		}
+	}
+}

--- a/compass-webapp/src/main/java/de/dfki/asr/compass/web/plugins/PluginViewRegistry.java
+++ b/compass-webapp/src/main/java/de/dfki/asr/compass/web/plugins/PluginViewRegistry.java
@@ -46,12 +46,12 @@ public class PluginViewRegistry {
 	 * @param viewId id to add to the slot
 	 */
 	public void registerPluginView(String slot, String viewId) {
-		if (!viewIds.containsKey(slot)) {
+		if (viewIds.containsKey(slot)) {
+			viewIds.get(slot).add(viewId);
+		} else {
 			Set<String> set = new HashSet<>();
 			set.add(viewId);
 			viewIds.put(slot, set);
-		} else {
-			viewIds.get(slot).add(viewId);
 		}
 		log.infov("Registered new view id {0} for slot {1}", viewId, slot);
 	};

--- a/compass-webapp/src/main/java/de/dfki/asr/compass/web/plugins/PluginViewRegistry.java
+++ b/compass-webapp/src/main/java/de/dfki/asr/compass/web/plugins/PluginViewRegistry.java
@@ -16,9 +16,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Collections;
 import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import org.jboss.logging.Logger;
 
+@ApplicationScoped
 public class PluginViewRegistry {
 
 	@Inject

--- a/compass-webapp/src/main/java/de/dfki/asr/compass/web/plugins/PluginViewRegistry.java
+++ b/compass-webapp/src/main/java/de/dfki/asr/compass/web/plugins/PluginViewRegistry.java
@@ -63,8 +63,10 @@ public class PluginViewRegistry {
 	 */
 	public List<String> getViewIdsForSlot(String slot) {
 		List<String> list = new ArrayList<>();
-		list.addAll(viewIds.get(slot));
-		Collections.sort(list);
+		if (viewIds.containsKey(slot)) {
+			list.addAll(viewIds.get(slot));
+			Collections.sort(list);
+		}
 		return list;
 	}
 

--- a/compass-webapp/src/main/java/de/dfki/asr/compass/web/plugins/PluginViewRegistry.java
+++ b/compass-webapp/src/main/java/de/dfki/asr/compass/web/plugins/PluginViewRegistry.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of COMPASS. It is subject to the license terms in
+ * the LICENSE file found in the top-level directory of this distribution.
+ * (Also avialable at http://www.apache.org/licenses/LICENSE-2.0.txt)
+ * You may not use this file except in compliance with the License.
+ */
+package de.dfki.asr.compass.web.plugins;
+
+import de.dfki.asr.compass.web.plugins.api.PluginAnnouncer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import javax.inject.Inject;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Collections;
+import javax.annotation.PostConstruct;
+import javax.enterprise.inject.Instance;
+import org.jboss.logging.Logger;
+
+public class PluginViewRegistry {
+
+	@Inject
+	private Logger log;
+
+	@Inject
+	private Instance<PluginAnnouncer> announcers;
+
+	private final Map<String, Set<String>> viewIds = new HashMap<>();
+
+	@PostConstruct
+	protected void collectAnnouncedPlugins() {
+		for (PluginAnnouncer announcer : announcers) {
+			log.infov("Asking {0} to announce its plugin view.", announcer.getClass().getPackage().getName());
+			announcer.announcePlugin(this);
+		}
+	}
+
+	/**
+	 * Called by announcer.announcePlugin.
+	 * Analog to ComponentRegistry mechanism.
+	 * @param slot slot the id is added to
+	 * @param viewId id to add to the slot
+	 */
+	public void registerPluginView(String slot, String viewId) {
+		if (!viewIds.containsKey(slot)) {
+			Set<String> set = new HashSet<>();
+			set.add(viewId);
+			viewIds.put(slot, set);
+		} else {
+			viewIds.get(slot).add(viewId);
+		}
+		log.infov("Registered new view id {0} for slot {1}", viewId, slot);
+	};
+
+	/**
+	 * Get a list of viewIds for a slot. ViewIds are sorted alphabetically, ascending.
+	 * @param slot for which the ids are requested
+	 * @return sorted list of view ids
+	 */
+	public List<String> getViewIdsForSlot(String slot) {
+		List<String> list = new ArrayList<>();
+		list.addAll(viewIds.get(slot));
+		Collections.sort(list);
+		return list;
+	}
+
+}
+

--- a/compass-webapp/src/main/java/de/dfki/asr/compass/web/plugins/api/PluginAnnouncer.java
+++ b/compass-webapp/src/main/java/de/dfki/asr/compass/web/plugins/api/PluginAnnouncer.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of COMPASS. It is subject to the license terms in
+ * the LICENSE file found in the top-level directory of this distribution.
+ * (Also avialable at http://www.apache.org/licenses/LICENSE-2.0.txt)
+ * You may not use this file except in compliance with the License.
+ */
+package de.dfki.asr.compass.web.plugins.api;
+
+import de.dfki.asr.compass.web.plugins.PluginViewRegistry;
+
+/**
+ * Announce plugin classes.
+ * Classes implementing this interface will be instantiated and have the announceComponents() method
+ * when the {@see PluginViewRegistry} is looking for plugins. Think of it as a plug-in discovery.
+ */
+public interface PluginAnnouncer {
+	/**
+	 * Called to query for new plugins.
+	 * When called, the method should invoke {@see PluginViewRegistry.registerPluginView} for each class
+	 * the plugin would like to register.
+	 * @param registry the registry with which to register component classes.
+	 */
+	void announcePlugin(PluginViewRegistry registry);
+}

--- a/compass-webapp/src/main/webapp/WEB-INF/compass.taglib.xml
+++ b/compass-webapp/src/main/webapp/WEB-INF/compass.taglib.xml
@@ -21,6 +21,12 @@
 			<component-type>compass.web.components.componenticons</component-type>
 		</component>
 	</tag>
+
+	<tag>
+		<tag-name>plugin</tag-name>
+		<handler-class>de.dfki.asr.compass.web.components.PluginTagHandler</handler-class>
+	</tag>
+
 	<function>
 		<function-name>truncateString</function-name>
 		<function-class>de.dfki.asr.compass.web.components.JSFFunctions</function-class>

--- a/compass-webapp/src/main/webapp/WEB-INF/compass.taglib.xml
+++ b/compass-webapp/src/main/webapp/WEB-INF/compass.taglib.xml
@@ -25,6 +25,11 @@
 	<tag>
 		<tag-name>plugin</tag-name>
 		<handler-class>de.dfki.asr.compass.web.components.PluginTagHandler</handler-class>
+		<attribute>
+			<name>slot</name>
+			<description>the plugin slot name for which to render plugins here</description>
+			<required>true</required>
+		</attribute>
 	</tag>
 
 	<function>

--- a/compass-webapp/src/main/webapp/editor/editor.xhtml
+++ b/compass-webapp/src/main/webapp/editor/editor.xhtml
@@ -125,5 +125,6 @@
 					autoUpdate="true"
 					closable="true"
 					redisplay="false"/>
+		<compass:plugin slot="body" />
 	</h:body>
 </html>

--- a/compass-webapp/src/main/webapp/editor/menu_bar.xhtml
+++ b/compass-webapp/src/main/webapp/editor/menu_bar.xhtml
@@ -81,6 +81,7 @@
 				</div>
 			</c:forEach>
 		</p:toolbarGroup>
+		<compass:plugin slot="menuBar"/>
 		<ui:insert name="header"/>
 	</p:toolbar>
 </ui:composition>

--- a/compass-webapp/src/main/webapp/editor/prefab_view.xhtml
+++ b/compass-webapp/src/main/webapp/editor/prefab_view.xhtml
@@ -140,6 +140,7 @@
 							 styleClass="compass-button"
 							 update=":prefabSelectionGridForm:prefabSelectionGrid"
 							 onclick="COMPASS.Importer.startPrefabImport();"/>
+			<compass:plugin slot="prefabButtons" />
 		</p:outputPanel>
 
 		<!-- templates -->


### PR DESCRIPTION
We have extension points for pretty much everything (cf. archetype), except for inserting content into JSF pages at more or less arbitrary points. Facelets' `<ui:include>` allows something along these lines, which is why we used it for `SceneNodeComponent` UIs. The approach used here is similar, in that applicable view pages are queried from a registry and rendered.
So why didn't we just use the same mechanic? Most of all, this is much more concise. Just one tag wherever you want your extension point to go. The SceneNodeComponent approach takes 2 Tags and a mandatory call to a Facelet function to resolve the view page.
