### PR TITLE
Remove ATLAS integration, for real this time.

### DIFF
--- a/compass-webapp/src/main/webapp/WEB-INF/components/rendergeometry.xhtml
+++ b/compass-webapp/src/main/webapp/WEB-INF/components/rendergeometry.xhtml
@@ -4,7 +4,8 @@
                 xmlns:h="http://java.sun.com/jsf/html"
                 xmlns:f="http://java.sun.com/jsf/core"
                 xmlns:p="http://primefaces.org/ui"
-				xmlns:c="http://java.sun.com/jsp/jstl/core">
+                xmlns:c="http://java.sun.com/jsp/jstl/core"
+                xmlns:compass="http://dfki.asr.de/compass/components">
 <!--
  This file is part of COMPASS. It is subject to the license terms in
  the LICENSE file found in the top-level directory of this distribution.
@@ -33,6 +34,7 @@
 					</p:column>
 				</p:row>
 			</p:panelGrid>
+			<compass:plugin slot="renderGeometryEditor"/>
 	</p:tab>
 </ui:composition>
 

--- a/compass-webapp/src/main/webapp/WEB-INF/components/rendergeometry.xhtml
+++ b/compass-webapp/src/main/webapp/WEB-INF/components/rendergeometry.xhtml
@@ -32,16 +32,6 @@
 						<p:message for="renderGeometryURLInput" id="msgRenderNodeURLInput"/>
 					</p:column>
 				</p:row>
-				<p:row>
-					<p:column colspan="3">
-						<p:commandButton value="From ATLAS"
-										 title="Select ATLAS Asset"
-										 styleClass="property-view-button"
-										 style="margin-top: 10px;"
-										 type="button"
-										 onclick="COMPASS.Importer.startURLImport();"/>
-					</p:column>
-				</p:row>
 			</p:panelGrid>
 	</p:tab>
 </ui:composition>

--- a/compass-webapp/src/main/webapp/resources/js/editor/remote-caller.js
+++ b/compass-webapp/src/main/webapp/resources/js/editor/remote-caller.js
@@ -171,11 +171,6 @@ XML3D.tools.namespace("COMPASS");
 			remoteUpdateSelectedSceneNodeTransform(transformEventData);
 		},
 
-		importAssetAsPrefab: function(assetURL) {
-			var data = [{name: "assetURL", value: assetURL}];
-			remoteImportAssetAsPrefab(data);
-		},
-
 		refreshSceneTree: function() {
 			remoteRefreshSceneTree();
 		},


### PR DESCRIPTION
There were some leftovers which needed pruning. However, there's now also a `renderGeometryEditor` slot.
It's not inside the `p:panelGrid`, as before, because PrimeFaces doesn't bother rendering any child that isn't a `p:row` (such as the plugin tag's required, but invisible, `UINamingContainer`).
