### PR TITLE
Feature/click extension support

### DIFF
--- a/compass-webapp/src/main/webapp/resources/js/editor/event-handler.js
+++ b/compass-webapp/src/main/webapp/resources/js/editor/event-handler.js
@@ -53,7 +53,7 @@ XML3D.tools.namespace("COMPASS");
 				hitPoint = new XML3DVec3([0, 0, 0]);
 				hitNormal = new XML3DVec3([0, 1, 0]);
 			}
-			return { point: hitPoint, normal: hitNormal };
+			return { point: hitPoint, normal: hitNormal, target: object };
 		},
 
 		onObjectDroppedOntoSceneHierarchy: function(evt, ui) {

--- a/compass-webapp/src/main/webapp/resources/js/editor/xml3d-producer.js
+++ b/compass-webapp/src/main/webapp/resources/js/editor/xml3d-producer.js
@@ -185,13 +185,10 @@ XML3D.tools.namespace("COMPASS");
 			var $group = this.findGroupForSceneNodeId(component.owner);
 			var meshNode = $group.find("model");
 			if (!meshNode.length) {
-				var onClickHandler = function() {
-					COMPASS.Editor.selectSceneNodeFromXML3D(component.owner);
-				};
 				meshNode = XML3D.tools.creation.element("model", {
 					src: component.meshSource
 				});
-				$(meshNode).click(onClickHandler);
+				$(meshNode).click(this._createMeshClickHandler(component));
 				$group.append(meshNode);
 				meshNode = $(meshNode);
 				meshNode.attr("data-componentid", component.id);
@@ -199,6 +196,12 @@ XML3D.tools.namespace("COMPASS");
 			if (meshNode.attr("src") !== component.meshSource) {
 				meshNode.attr("src", component.meshSource);
 			}
+		},
+
+		_createMeshClickHandler: function(renderGeometryComponent) {
+			return function() {
+				COMPASS.Editor.selectSceneNodeFromXML3D(renderGeometryComponent.owner);
+			};
 		},
 
 		_convertDirectionalLightNodeComponent: function(component) {


### PR DESCRIPTION
This feature allows COMPASS based apps to customize the handling of clicking a geometry object. It therefore introduces a method `XML3DProducer._createMeshClickHandler`, which can be hooked using jQuery-AOP (as opposed to the previously anonymous generation of the handler).
It also makes the `EventHandler._getMouseHitInformation` return the object tag which was hit by the scan ray. The latter is not relevant in the original context of that function, but it makes the function much more useful for an outside user.
