### PR TITLE
Feature/test coverage reports

### DIFF
--- a/compass-model/pom.xml
+++ b/compass-model/pom.xml
@@ -78,6 +78,16 @@
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
 			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<!-- JPA Metamodel: -->
+						<exclude>**/*_.class</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<compilerArgument>-proc:none</compilerArgument>

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,27 @@
 					<artifactId>versions-maven-plugin</artifactId>
 					<version>2.1</version>
 				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.7.4.201502262128</version>
+					<executions>
+						<execution>
+							<id>default-prepare-agent</id>
+							<goals>
+								<goal>prepare-agent</goal>
+							</goals>
+						</execution>
+						<execution>
+							<id>default-report</id>
+							<inherited>true</inherited>
+							<phase>prepare-package</phase>
+							<goals>
+								<goal>report</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
This feature adds JaCoCo as coverage reports. For me, it was the coverage tool with the best compatibility, which is why I chose it. The others (e.g. emma) struggle with Java 7 and outright don't work on Java 8. I found it pretty neat from a technical standpoint, as it uses the same facility as the remote debugger.
As is usual, it can be enabled per-module, like PMD and CPD.
