### PR TITLE
Speed up travis build and reduce travis traffic usage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   - $HOME/.m2
 before_cache:
   - rm -rf $HOME/.m2/repository/de/dfki/asr
-  - rm -rf $HOME/.m2/archetype-catalog.xml
+  - rm -f $HOME/.m2/archetype-catalog.xml
 notifications:
   slack:
     secure: NiXeJ2YlXgPTRk/iwo76XdTWXELGnu/wSX4ZT2N1Pmhkg0A2IExm4TkKhXVmSXoYPuiuF3/7BRf3VM4uRwLex/WkdEQXqwA3aXChNdkRBnRseUwEMBgNvKOVjZXExHzs91bH+wr4m7L1qqpvQikYOMtSsVc/4Oh8cTNUAeGITlc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 cache:
   directories:
   - $HOME/.m2
+before_cache:
+  - rm -rf $HOME/.m2/repository/de/dfki/asr
 notifications:
   slack:
     secure: NiXeJ2YlXgPTRk/iwo76XdTWXELGnu/wSX4ZT2N1Pmhkg0A2IExm4TkKhXVmSXoYPuiuF3/7BRf3VM4uRwLex/WkdEQXqwA3aXChNdkRBnRseUwEMBgNvKOVjZXExHzs91bH+wr4m7L1qqpvQikYOMtSsVc/4Oh8cTNUAeGITlc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   - $HOME/.m2
 before_cache:
   - rm -rf $HOME/.m2/repository/de/dfki/asr
+  - rm -rf $HOME/.m2/archetype-catalog.xml
 notifications:
   slack:
     secure: NiXeJ2YlXgPTRk/iwo76XdTWXELGnu/wSX4ZT2N1Pmhkg0A2IExm4TkKhXVmSXoYPuiuF3/7BRf3VM4uRwLex/WkdEQXqwA3aXChNdkRBnRseUwEMBgNvKOVjZXExHzs91bH+wr4m7L1qqpvQikYOMtSsVc/4Oh8cTNUAeGITlc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: java
+sudo: false
+cache:
+  directories:
+  - $HOME/.m2
 notifications:
   slack:
     secure: NiXeJ2YlXgPTRk/iwo76XdTWXELGnu/wSX4ZT2N1Pmhkg0A2IExm4TkKhXVmSXoYPuiuF3/7BRf3VM4uRwLex/WkdEQXqwA3aXChNdkRBnRseUwEMBgNvKOVjZXExHzs91bH+wr4m7L1qqpvQikYOMtSsVc/4Oh8cTNUAeGITlc=


### PR DESCRIPTION
By caching (most of) `~/.m2/` local maven repository, I hope travis is a bit more happy with us.
We were downloading an entire WildFly every build, after all.
