### PR TITLE
Check for duplicate project names before saving the project

### DIFF
--- a/compass-business-impl/src/main/java/de/dfki/asr/compass/business/ProjectManagerImpl.java
+++ b/compass-business-impl/src/main/java/de/dfki/asr/compass/business/ProjectManagerImpl.java
@@ -8,9 +8,11 @@ package de.dfki.asr.compass.business;
 
 import de.dfki.asr.compass.business.api.ProjectManager;
 import de.dfki.asr.compass.business.exception.CompassRuntimeException;
+import de.dfki.asr.compass.business.exception.EntityConstraintException;
 import de.dfki.asr.compass.business.exception.EntityNotFoundException;
 import de.dfki.asr.compass.business.exception.PersistenceException;
 import de.dfki.asr.compass.model.Project;
+import de.dfki.asr.compass.model.Project_;
 import de.dfki.asr.compass.model.Scenario;
 import de.dfki.asr.compass.business.services.CRUDService;
 import java.io.IOException;
@@ -19,6 +21,9 @@ import java.util.List;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 
 @Named
 @Stateless
@@ -29,6 +34,9 @@ public class ProjectManagerImpl implements Serializable, ProjectManager {
 	@Inject
 	private CRUDService crudService;
 
+	@Inject
+	private CriteriaBuilder criteriaBuilder;
+
 	@Override
 	public Project findById(final long id) throws EntityNotFoundException {
 		return crudService.findById(Project.class, id);
@@ -36,7 +44,7 @@ public class ProjectManagerImpl implements Serializable, ProjectManager {
 
 	@Override
 	public void removeById(final long entityId) throws EntityNotFoundException {
-		remove(findById(entityId) );
+		remove(findById(entityId));
 	}
 
 	@Override
@@ -72,12 +80,14 @@ public class ProjectManagerImpl implements Serializable, ProjectManager {
 
 	@Override
 	public void createNewProject(final String name) throws PersistenceException {
+		ensureUniqueName(name);
 		Project newProject = new Project(name);
 		crudService.save(newProject);
 	}
 
 	@Override
 	public void copyProject(final Project project, final String nameForCopy) throws PersistenceException {
+		ensureUniqueName(nameForCopy);
 		Project attached = crudService.attach(project);
 		Project newProject;
 		try {
@@ -91,10 +101,26 @@ public class ProjectManagerImpl implements Serializable, ProjectManager {
 
 	@Override
 	public void setProjectName(final Project project, final String projectName) throws PersistenceException {
-		if (project.getName().equals(projectName)) {
-			return;
+		if (!project.getName().equals(projectName)) {
+			ensureUniqueName(projectName);
+			project.setName(projectName);
 		}
-		project.setName(projectName);
 		crudService.save(project);
+	}
+
+	@Override
+	public boolean isNameUnique(final String name) {
+		CriteriaQuery<Long> q = criteriaBuilder.createQuery(Long.class);
+		Root<Project> p = q.from(Project.class);
+		q.where(criteriaBuilder.equal(p.get(Project_.name), name));
+		q.select(criteriaBuilder.count(p));
+		Long count = crudService.createQuery(q).getSingleResult();
+		return count == 0;
+	}
+
+	private void ensureUniqueName(final String name) {
+		if (!isNameUnique(name)) {
+			throw new EntityConstraintException("A project of the given name already exists.");
+		}
 	}
 }

--- a/compass-business-impl/src/main/java/de/dfki/asr/compass/business/api/ProjectManager.java
+++ b/compass-business-impl/src/main/java/de/dfki/asr/compass/business/api/ProjectManager.java
@@ -65,4 +65,12 @@ public interface ProjectManager extends Manager<Project> {
 	 * @return list of all projects
 	 */
 	List<Project> getAllProjects();
+
+	/**
+	 * Check if a given name is already used.
+	 *
+	 * @param name name to check
+	 * @return boolean
+	 */
+	boolean isNameUnique(final String name);
 }


### PR DESCRIPTION
Check for duplicate project names when posting or putting via REST. If a name is already used an error will be thrown.
