### PR TITLE
Feature/entitymanager scope

### DIFF
--- a/compass-business-impl/src/main/java/de/dfki/asr/compass/business/services/CRUDService.java
+++ b/compass-business-impl/src/main/java/de/dfki/asr/compass/business/services/CRUDService.java
@@ -14,7 +14,7 @@ import de.dfki.asr.compass.business.exception.EntityNotFoundException;
 import de.dfki.asr.compass.business.exception.PersistenceException;
 import de.dfki.asr.compass.model.AbstractCompassEntity;
 import java.util.List;
-import javax.ejb.Singleton;
+import javax.ejb.Stateless;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -23,7 +23,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import org.hibernate.HibernateException;
 import org.hibernate.exception.ConstraintViolationException;
 
-@Singleton
+@Stateless
 public class CRUDService {
 
 	@Inject

--- a/compass-business-impl/src/main/java/de/dfki/asr/compass/cdi/producers/EntityManagerProducer.java
+++ b/compass-business-impl/src/main/java/de/dfki/asr/compass/cdi/producers/EntityManagerProducer.java
@@ -7,7 +7,7 @@
 package de.dfki.asr.compass.cdi.producers;
 
 import javax.ejb.Stateful;
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.SessionScoped;
 import javax.enterprise.inject.Produces;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -22,7 +22,7 @@ import javax.persistence.criteria.CriteriaBuilder;
  * {@link PersistenceContextType.EXTENDED}.
  */
 @Stateful
-@ApplicationScoped
+@SessionScoped
 public class EntityManagerProducer {
 
 	@PersistenceContext(type = PersistenceContextType.EXTENDED)

--- a/compass-business-impl/src/main/java/de/dfki/asr/compass/cdi/producers/EntityManagerProducer.java
+++ b/compass-business-impl/src/main/java/de/dfki/asr/compass/cdi/producers/EntityManagerProducer.java
@@ -7,7 +7,7 @@
 package de.dfki.asr.compass.cdi.producers;
 
 import javax.ejb.Stateful;
-import javax.enterprise.context.SessionScoped;
+import javax.enterprise.context.ConversationScoped;
 import javax.enterprise.inject.Produces;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -22,7 +22,7 @@ import javax.persistence.criteria.CriteriaBuilder;
  * {@link PersistenceContextType.EXTENDED}.
  */
 @Stateful
-@SessionScoped
+@ConversationScoped
 public class EntityManagerProducer {
 
 	@PersistenceContext(type = PersistenceContextType.EXTENDED)

--- a/compass-webapp/src/main/java/de/dfki/asr/compass/web/backingbeans/project/OpenScenarioBean.java
+++ b/compass-webapp/src/main/java/de/dfki/asr/compass/web/backingbeans/project/OpenScenarioBean.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.PostConstruct;
+import javax.enterprise.context.Conversation;
 import javax.enterprise.context.SessionScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.event.Reception;
@@ -37,6 +38,9 @@ public class OpenScenarioBean extends CompassBean implements Serializable {
 	private static final long serialVersionUID = 181147082297722948L;
 
 	@Inject
+	protected Conversation conversation;
+
+	@Inject
 	protected Logger log;
 
 	@Inject
@@ -51,6 +55,7 @@ public class OpenScenarioBean extends CompassBean implements Serializable {
 
 	@PostConstruct
 	public void startProjectSelection() {
+		conversation.begin(); // from here on out, keep an entityManager.
 		fetchProjects();
 		scenarioList = new ArrayList<>();
 		if (!projectList.isEmpty()) {


### PR DESCRIPTION
`CRUDService` is no longer a Singleton (avoiding concurrency issues). `@Stateless` beans however, default to `RequestScoped`, which is too short a lifetime for the `EntityManager`. Since the EM is held in the Producer (and no longer implicitly in the `CRUDService`), we prolong the lifetime of the Producer to `ConversationScoped`. (And explicitly extend _that_ to what amounts to SessionScoped for JSF.)

So much functional for so little code change. I'm impressed and scared at the same time.
