### PR TITLE
Feature/fix issue 7

### DIFF
--- a/compass-webapp/src/main/webapp/resources/js/editor/xml3d-producer.js
+++ b/compass-webapp/src/main/webapp/resources/js/editor/xml3d-producer.js
@@ -105,6 +105,9 @@ XML3D.tools.namespace("COMPASS");
 		},
 
 		_convertSceneNode: function(sceneNode) {
+			if (this._isPrefab(sceneNode)) {
+				return;
+			}
 			var parentGroup = this._findParentGroupForSceneNode(sceneNode);
 			var group = this.findGroupForSceneNodeId(sceneNode.id);
 			if (!group.length) {
@@ -122,6 +125,15 @@ XML3D.tools.namespace("COMPASS");
 			this._convertSceneNodeTransform(sceneNode, group);
 			this._convertSceneNodeComponents(sceneNode);
 			this._convertSceneNodeChildren(sceneNode, group);
+		},
+
+		_isPrefab: function(sceneNode) {
+			if (sceneNode.parent !== null) {
+				return false;
+			} else {
+				var rootNodeId = this.xml3d.getAttribute(this.ROOTNODE_ID_ATTRIBUTE);
+				return sceneNode.id !== Number.parseInt(rootNodeId);
+			}
 		},
 
 		updateGroupStructureForSceneNode: function($groupNode, sceneNode) {

--- a/compass-webapp/src/main/webapp/resources/js/editor/xml3d-producer.js
+++ b/compass-webapp/src/main/webapp/resources/js/editor/xml3d-producer.js
@@ -127,12 +127,16 @@ XML3D.tools.namespace("COMPASS");
 			this._convertSceneNodeChildren(sceneNode, group);
 		},
 
+		_isRootNode: function(sceneNode) {
+			var rootNodeId = this.xml3d.getAttribute(this.ROOTNODE_ID_ATTRIBUTE);
+			return sceneNode.id === Number.parseInt(rootNodeId);
+		},
+
 		_isPrefab: function(sceneNode) {
 			if (sceneNode.parent !== null) {
 				return false;
 			} else {
-				var rootNodeId = this.xml3d.getAttribute(this.ROOTNODE_ID_ATTRIBUTE);
-				return sceneNode.id !== Number.parseInt(rootNodeId);
+				return !this._isRootNode(sceneNode);
 			}
 		},
 

--- a/compass-webapp/src/main/webapp/resources/js/editor/xml3d-producer.js
+++ b/compass-webapp/src/main/webapp/resources/js/editor/xml3d-producer.js
@@ -105,7 +105,7 @@ XML3D.tools.namespace("COMPASS");
 		},
 
 		_convertSceneNode: function(sceneNode) {
-			if (this._isPrefab(sceneNode)) {
+			if (this._isPrefab(sceneNode) || this._isDifferentScenario(sceneNode)) {
 				return;
 			}
 			var parentGroup = this._findParentGroupForSceneNode(sceneNode);
@@ -138,6 +138,14 @@ XML3D.tools.namespace("COMPASS");
 			} else {
 				return !this._isRootNode(sceneNode);
 			}
+		},
+
+		_isDifferentScenario: function(sceneNode) {
+			var parent = document.getElementById(this.SCENENODE_ID_PREFIX + sceneNode.parent);
+			// crude heuristic: If we don't have the parent...
+			// - Either the node is not part of our scenario
+			// - Or ordering of events screwed up (child before parent)
+			return parent === null && !this._isRootNode(sceneNode);
 		},
 
 		updateGroupStructureForSceneNode: function($groupNode, sceneNode) {


### PR DESCRIPTION
The changes in this PR add some sanity checks before modifying the XML3D scene when a node comes in via REST. Most noticably, changes triggered by STOMP shouldn't lead to erroneous additions to the scene any more.
Especially, it should fix #7.
